### PR TITLE
Fix support for Laravel 5.8+

### DIFF
--- a/src/Laravel/CacheItemPool.php
+++ b/src/Laravel/CacheItemPool.php
@@ -152,19 +152,16 @@ class CacheItemPool implements CacheItemPoolInterface
             return true;
         }
 
-        $now = new DateTimeImmutable('now', $expiresAt->getTimezone());
+        $lifetime = LifetimeHelper::computeLifetime($expiresAt);
 
-        $seconds = $expiresAt->getTimestamp() - $now->getTimestamp();
-        $minutes = (int) floor($seconds / 60.0);
-
-        if ($minutes <= 0) {
+        if ($lifetime <= 0) {
             $this->repository->forget($item->getKey());
 
             return false;
         }
 
         try {
-            $this->repository->put($item->getKey(), serialize($item->get()), $minutes);
+            $this->repository->put($item->getKey(), serialize($item->get()), $lifetime);
         } catch (Exception $exception) {
             return false;
         }

--- a/src/Laravel/LifetimeHelper.php
+++ b/src/Laravel/LifetimeHelper.php
@@ -1,0 +1,32 @@
+<?php
+namespace Madewithlove\IlluminatePsrCacheBridge\Laravel;
+
+use DateTimeImmutable;
+use DateTimeInterface;
+use Exception;
+use Illuminate\Contracts\Cache\Store;
+use ReflectionClass;
+
+class LifetimeHelper
+{
+    public static function computeLifetime(DateTimeInterface $expiresAt)
+    {
+        $now = new DateTimeImmutable('now', $expiresAt->getTimezone());
+
+        $seconds = $expiresAt->getTimestamp() - $now->getTimestamp();
+
+        return self::isLegacy() ? (int) floor($seconds / 60.0) : $seconds;
+    }
+
+    private static function isLegacy()
+    {
+        static $legacy;
+
+        if ($legacy === null) {
+            $params = (new ReflectionClass(Store::class))->getMethod('put')->getParameters();
+            $legacy = $params[2]->getName() === 'minutes';
+        }
+
+        return $legacy;
+    }
+}


### PR DESCRIPTION
In Laravel 5.8, the cache store interface was modified to expect seconds instead of minutes.

This PR fixes support for Laravel 5.8+, while retaining support for Laravel 5.0-5.7.

---

Closes #15.