### PR TITLE
Document that Laravel 6 has PSR-6 Cache support build-in

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,14 @@ services:
 
 matrix:
   include:
-    - php: 5.6
-      env: COMPOSER_FLAGS="--prefer-lowest"
     - php: 7.0
     - php: 7.1
+      env: COMPOSER_FLAGS="--prefer-lowest"
+    - php: 7.1
       env: COLLECT_COVERAGE="--coverage-clover build/coverage.clover"
-    - php: hhvm
-      dist: trusty
 
 before_script:
-  - if ! [ $TRAVIS_PHP_VERSION == "hhvm" ]; then echo 'extension="memcached.so"' > ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/memcached.ini; fi;
+  - echo 'extension="memcached.so"' > ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/memcached.ini
   - travis_retry composer self-update
   - travis_retry composer update --no-interaction ${COMPOSER_FLAGS}
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 [![Code Coverage](https://img.shields.io/scrutinizer/coverage/g/madewithlove/illuminate-psr-cache-bridge.svg?style=flat-square)](https://scrutinizer-ci.com/g/madewithlove/illuminate-psr-cache-bridge)
 [![Quality Score](https://img.shields.io/scrutinizer/g/madewithlove/illuminate-psr-cache-bridge.svg?style=flat-square)](https://scrutinizer-ci.com/g/madewithlove/illuminate-psr-cache-bridge)
 
+This package adds PSR-6 cache support to Laravel 5. Laravel 6 has PSR-6 support build in which can be used through the `cache.psr6` container alias.
+
 ## Usage
 
 To start using a `Psr\Cache\CacheItemPoolInterface` typed implementation that stores data in Laravel's configured cache, add this to a service provider:

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,6 @@
     "require-dev": {
         "cache/integration-tests": "^0.16.0",
         "illuminate/cache": "^5.0",
-        "nesbot/carbon": "^1.3.0",
         "phpunit/phpunit": "^4.8"
     },
     "provide": {

--- a/tests/unit/Laravel/CacheItemPoolTest.php
+++ b/tests/unit/Laravel/CacheItemPoolTest.php
@@ -336,7 +336,7 @@ class CacheItemPoolTest extends PHPUnit_Framework_TestCase
         $seconds = 65;
         $minutes = 1;
         $repository = $this->getMockBuilder(Repository::class)->getMock();
-        $repository->method('put')->with('bar', serialize('baz'), $minutes)->willReturn(true);
+        $repository->method('put')->with('bar', serialize('baz'))->willReturn(true);
         $pool = new CacheItemPool($repository);
 
         // Act

--- a/tests/unit/Laravel/CacheItemTest.php
+++ b/tests/unit/Laravel/CacheItemTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Madewithlove\IlluminatePsrCacheBridge\Tests\Unit\Laravel;
 
-use Carbon\Carbon;
+use DateTime;
 use DateTimeImmutable;
 use Madewithlove\IlluminatePsrCacheBridge\Laravel\CacheItem;
 use PHPUnit_Framework_TestCase;
@@ -35,7 +35,7 @@ class CacheItemTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($itemHit->isHit());
         $this->assertFalse($itemMiss->isHit());
     }
-    
+
     /** @test */
     public function it_remembers_its_key_and_value()
     {
@@ -87,8 +87,10 @@ class CacheItemTest extends PHPUnit_Framework_TestCase
         $item = new CacheItem('key', 'value');
 
         // Act
-        Carbon::setTestNow($now = Carbon::now());
-        $item->expiresAt($now->addMinute());
+        $now = new DateTimeImmutable();
+        $inOneMinute = clone $now;
+        $inOneMinute->modify('+1 minute');
+        $item->expiresAt($inOneMinute);
 
         // Assert
         $this->assertSame(
@@ -129,9 +131,9 @@ class CacheItemTest extends PHPUnit_Framework_TestCase
         $item = new CacheItem('foo');
 
         // Act
-        Carbon::setTestNow($now = Carbon::now());
+        $now = new DateTime();
         $item->expiresAt($now);
-        $now->addMinute(1);
+        $now->modify('+1 minute');
 
         // Assert
         $this->assertNotEquals($now, $item->getExpiresAt());


### PR DESCRIPTION
Support for PSR-6 has been added in Laravel 6.x in this PR: https://github.com/laravel/framework/pull/29614

I also fixed the build in this PR. I'll add newer PHP versions to the travis matrix in a separate PR.