### PR TITLE
Add support for newer PHP versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,12 @@ matrix:
     - php: 7.1
       env: COMPOSER_FLAGS="--prefer-lowest"
     - php: 7.1
+    - php: 7.2
+      env: COMPOSER_FLAGS="--prefer-lowest"
+    - php: 7.2
+    - php: 7.3
+      env: COMPOSER_FLAGS="--prefer-lowest"
+    - php: 7.3
       env: COLLECT_COVERAGE="--coverage-clover build/coverage.clover"
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ services:
 
 matrix:
   include:
-    - php: 7.0
     - php: 7.1
       env: COMPOSER_FLAGS="--prefer-lowest"
     - php: 7.1

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require-dev": {
         "cache/integration-tests": "^0.16.0",
         "illuminate/cache": "^5.0",
-        "phpunit/phpunit": "^4.8"
+        "phpunit/phpunit": "^7.0"
     },
     "provide": {
         "psr/cache-implementation": "1.0.0"

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     "require-dev": {
         "illuminate/cache": "^5.0",
         "phpunit/phpunit": "^7.0",
-        "cache/integration-tests": "dev-master"
+        "cache/integration-tests": "dev-master",
+        "symfony/phpunit-bridge": "^5.0"
     },
     "provide": {
         "psr/cache-implementation": "1.0.0"

--- a/composer.json
+++ b/composer.json
@@ -9,9 +9,9 @@
         "psr/cache": "^1.0"
     },
     "require-dev": {
-        "cache/integration-tests": "^0.16.0",
         "illuminate/cache": "^5.0",
-        "phpunit/phpunit": "^7.0"
+        "phpunit/phpunit": "^7.0",
+        "cache/integration-tests": "dev-master"
     },
     "provide": {
         "psr/cache-implementation": "1.0.0"

--- a/tests/integration/IntegrationTest.php
+++ b/tests/integration/IntegrationTest.php
@@ -10,6 +10,10 @@ use Psr\Cache\CacheItemPoolInterface;
 
 class IntegrationTest extends CachePoolTest
 {
+    protected $skippedTests = [
+        'testBasicUsageWithLongKey' => 'Memcached does not support key lenght over 250 characters.',
+    ];
+
     /**
      * @return CacheItemPoolInterface that is used in the tests
      */

--- a/tests/unit/Exceptions/InvalidArgumentExceptionTest.php
+++ b/tests/unit/Exceptions/InvalidArgumentExceptionTest.php
@@ -3,9 +3,9 @@ namespace Madewithlove\IlluminatePsrCacheBridge\Tests\Unit\Exceptions;
 
 use Exception;
 use Madewithlove\IlluminatePsrCacheBridge\Exceptions\InvalidArgumentException;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class InvalidArgumentExceptionTest extends PHPUnit_Framework_TestCase
+class InvalidArgumentExceptionTest extends TestCase
 {
     /** @test */
     public function it_can_be_constructed()

--- a/tests/unit/Laravel/CacheItemPoolTest.php
+++ b/tests/unit/Laravel/CacheItemPoolTest.php
@@ -5,11 +5,11 @@ use Exception;
 use Illuminate\Contracts\Cache\Repository;
 use Illuminate\Contracts\Cache\Store;
 use Madewithlove\IlluminatePsrCacheBridge\Laravel\CacheItemPool;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemPoolInterface;
 use Psr\Cache\InvalidArgumentException;
 
-class CacheItemPoolTest extends PHPUnit_Framework_TestCase
+class CacheItemPoolTest extends TestCase
 {
     /** @test */
     public function it_can_be_constructed()
@@ -104,7 +104,7 @@ class CacheItemPoolTest extends PHPUnit_Framework_TestCase
         $repository = $this->getMockBuilder(Repository::class)->getMock();
         $pool = new CacheItemPool($repository);
 
-        $this->setExpectedException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         // Act
         $pool->hasItem('foo@bar');
@@ -179,7 +179,7 @@ class CacheItemPoolTest extends PHPUnit_Framework_TestCase
         $repository = $this->getMockBuilder(Repository::class)->getMock();
         $pool = new CacheItemPool($repository);
 
-        $this->setExpectedException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         // Act
         $pool->deleteItem('@');
@@ -194,7 +194,7 @@ class CacheItemPoolTest extends PHPUnit_Framework_TestCase
         $repository = $this->getMockBuilder(Repository::class)->getMock();
         $pool = new CacheItemPool($repository);
 
-        $this->setExpectedException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         // Act
         $pool->deleteItems(['bar', 'foo', '{', '@']);

--- a/tests/unit/Laravel/CacheItemTest.php
+++ b/tests/unit/Laravel/CacheItemTest.php
@@ -4,10 +4,10 @@ namespace Madewithlove\IlluminatePsrCacheBridge\Tests\Unit\Laravel;
 use DateTime;
 use DateTimeImmutable;
 use Madewithlove\IlluminatePsrCacheBridge\Laravel\CacheItem;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemInterface;
 
-class CacheItemTest extends PHPUnit_Framework_TestCase
+class CacheItemTest extends TestCase
 {
     /** @test */
     public function it_can_be_constructed()


### PR DESCRIPTION
This makes sure we run tests on newer PHP versions (7.2 and 7.3) both with the lowest and highest composer dependencies. This should make sure that we're future proof.